### PR TITLE
Fix: Remove references to phpstan/phpstan

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,5 @@
 /.php_cs                        export-ignore
 /composer-require-checker.json  export-ignore
 /Makefile                       export-ignore
-/phpstan-baseline.neon          export-ignore
-/phpstan.neon                   export-ignore
 /psalm-baseline.xml             export-ignore
 /psalm.xml                      export-ignore


### PR DESCRIPTION
This pull request

* [x] removes references to `phpstan/phpstan`