### PR TITLE
Fix: Exclude phpunit/phpunit from Dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,10 @@ updates:
       include: "scope"
       prefix: "composer"
     directory: "/"
+    ignore:
+      - dependency-name: "phpunit/phpunit"
+        versions:
+          - ">= 0"
     labels:
       - "dependency"
     open-pull-requests-limit: 10


### PR DESCRIPTION
This pull request

* [x] excludes `phpunit/phpunit` from Dependabot updates