### PR TITLE
Fix: Disable fixers

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -17,7 +17,10 @@ $license = License\Type\MIT::markdown(
 
 $license->save();
 
-$config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\Php74(''));
+$config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\Php74(''), [
+    'php_unit_internal_class' => false,
+    'php_unit_test_class_requires_covers' => false,
+]);
 
 $config->getFinder()
     ->exclude([


### PR DESCRIPTION
This pull request

* [x] disables a few fixers which appear to have false positives when detecting test classes